### PR TITLE
chore(pyproject) + fix(deploy): licença GPL-3.0 e versões de imagens v1.2.4.1

### DIFF
--- a/env_files/default.env
+++ b/env_files/default.env
@@ -16,11 +16,11 @@ export SOLR_MLT_JURISPRUDENCE_CORE="documentos_bm25"   # Define o nome do core d
 export SOLR_MLT_PROCESS_CORE="processos_bm25"          # Define o nome do core de processos do Solr do SEI IA.
 
 #### Versao das Imagens do SEI IA.
-export API_SEI_IMAGE="1.2.3"              # Define a versão da imagem da API SEI.
-export API_ASSISTENTE_VERSION="1.2.6"     # Define a versão da imagem da API do Assistente.
-export NGINX_ASSISTENTE_VERSION="1.2.6"   # Define a versão da imagem do Nginx do Assistente.
-export AIRFLOW_IMAGE_NAME="1.2.9"         # Define a versão da imagem do Airflow.
-export APP_API="1.2.1"                    # Define a versão da imagem da API do aplicativo.
+export API_SEI_IMAGE="1.2.5"              # Define a versão da imagem da API SEI.
+export API_ASSISTENTE_VERSION="1.2.7"     # Define a versão da imagem da API do Assistente.
+export NGINX_ASSISTENTE_VERSION="1.2.7"   # Define a versão da imagem do Nginx do Assistente.
+export AIRFLOW_IMAGE_NAME="1.2.10"        # Define a versão da imagem do Airflow.
+export APP_API="1.2.2"                    # Define a versão da imagem da API do aplicativo.
 export SOLR_CONTAINER="1.1.0"             # Define a versão da imagem do Solr.
 export POSTGRES_IMAGE="1.1.1"             # Define a versão da imagem do Postgres.
 
@@ -62,8 +62,8 @@ export ASSISTENTE_USE_LANGFUSE=false
 export ENABLE_OTEL_METRICS=false
 
 # Variáveis para rastrear versão deploy externo
-HASH_ESCAPED='a399b8070f5c6578756fde45282cce3369a11512'
+HASH_ESCAPED='f4c09b4cfbf54c156db3a495742471954ce8982c'
 BRANCH_ESCAPED='master'
-TAG_ESCAPED='v1.2.2'
+TAG_ESCAPED='v1.2.4.1'
 URL_ESCAPED='git@git.anatel.gov.br:processo_eletronico/sei-ia/sei-similaridade/deploy.git/jobs.git'
-CURRENT_TIME='2026-03-18 19:03:24'
+CURRENT_TIME='2026-05-20 09:12:33'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "sei-ia"
 version = "0.1.0"
 description = "SEI-IA - Inteligência Artificial para o SEI"
 authors = [{name = "Anatel", email = "seiia@anatel.gov.br"}]
+license = {file = "LICENSE"}
 requires-python = ">=3.10"
 
 dependencies = [


### PR DESCRIPTION
## Summary
- **`pyproject.toml`**: adiciona `license = {file = "LICENSE"}` apontando para o `LICENSE` GPL-3.0 já existente na raiz.
- **`env_files/default.env`**: atualiza versões das imagens publicadas para o release **v1.2.4.1**:
  - `API_SEI_IMAGE` 1.2.3 → 1.2.5
  - `API_ASSISTENTE_VERSION` 1.2.6 → 1.2.7
  - `NGINX_ASSISTENTE_VERSION` 1.2.6 → 1.2.7
  - `AIRFLOW_IMAGE_NAME` 1.2.9 → 1.2.10
  - `APP_API` 1.2.1 → 1.2.2
  - `TAG_ESCAPED` v1.2.2 → v1.2.4.1 (+ HASH e CURRENT_TIME)

> Nota: `tests/env_tests.py` e `docs/{INSTALL,UPGRADE}.md` foram mantidos como na `main` do github (docs já estão mais novos com a seção de WebSearch; `env_tests.py` continua exigindo `SEI_API_DB_CHUNK_SIZE` que segue declarado em `security_example.env` e usado em `docker-compose-prod.yaml`).

## Test plan
- [ ] `pip install .` ou `python -m build` sem erros relacionados à licença.
- [ ] `pip show sei-ia` exibe a licença GPL-3.0.
- [ ] Healthchecker valida o novo `default.env` sem reportar variáveis faltantes/extras.
- [ ] Pull das imagens nas tags novas funciona no registry.