### PR TITLE
feat(infra): add Google Cloud Vertex AI support via LiteLLM Proxy

### DIFF
--- a/.gitlab/scripts/generate_config_files.sh
+++ b/.gitlab/scripts/generate_config_files.sh
@@ -95,6 +95,9 @@ generate_security_env() {
     printf '%s=%s\n' "LITELLM_STANDARD_MODEL"                    "${LITELLM_STANDARD_MODEL:-}"
     printf '%s=%s\n' "LITELLM_MINI_MODEL"                        "${LITELLM_MINI_MODEL:-}"
     printf '%s=%s\n' "LITELLM_NANO_MODEL"                        "${LITELLM_NANO_MODEL:-}"
+    printf '%s=%s\n' "LITELLM_VERTEX_PROJECT"                    "${LITELLM_VERTEX_PROJECT:-}"
+    printf '%s=%s\n' "LITELLM_VERTEX_LOCATION"                   "${LITELLM_VERTEX_LOCATION:-}"
+    printf '%s=%s\n' "LITELLM_VERTEX_CREDENTIALS"                "${LITELLM_VERTEX_CREDENTIALS:-}"
     printf '%s=%s\n' "SEI_API_DB_IDENTIFIER_SERVICE"             "${SEI_API_DB_IDENTIFIER_SERVICE:-}"
     printf '%s=%s\n' "SEI_ADDRESS"                       "${SEI_ADDRESS:-}"
     printf '%s=%s\n' "PROJECT_ENDPOINT"                  "${PROJECT_ENDPOINT:-}"
@@ -122,8 +125,8 @@ generate_litellm_config() {
     return 0
   fi
 
-  if [ -z "${LITELLM_STANDARD_API_KEY:-}" ]; then
-    log "LITELLM_STANDARD_API_KEY nao configurada no GitLab; pulando geracao de $out"
+  if [ -z "${LITELLM_STANDARD_API_KEY:-}" ] && [ -z "${LITELLM_VERTEX_CREDENTIALS:-}" ]; then
+    log "Nem LITELLM_STANDARD_API_KEY nem LITELLM_VERTEX_CREDENTIALS configuradas no GitLab; pulando geracao de $out"
     return 0
   fi
 
@@ -142,7 +145,10 @@ ${LITELLM_EMBEDDING_API_VERSION}
 ${LITELLM_STT_MODEL}
 ${LITELLM_STT_API_BASE}
 ${LITELLM_STT_API_KEY}
-${LITELLM_STT_API_VERSION}' \
+${LITELLM_STT_API_VERSION}
+${LITELLM_VERTEX_PROJECT}
+${LITELLM_VERTEX_LOCATION}
+${LITELLM_VERTEX_CREDENTIALS}' \
     < "$template" > "$out"
   log "litellm_config.yaml gerado com sucesso"
 }

--- a/aplicacoes/assistente/sei_ia/services/llm_models/get_model.py
+++ b/aplicacoes/assistente/sei_ia/services/llm_models/get_model.py
@@ -132,12 +132,18 @@ def get_model(
     # Obtém configurações do modelo
     config = get_model_config(model_type)
 
-    # Para modelos de raciocínio (think), força temperature=1.0
-    # O proxy LiteLLM/Azure OpenAI exige isso para modelos GPT-5
-    if model_type.lower() == "think":
+    # Para modelos de raciocínio (think), força temperature=1.0 para Azure/OpenAI
+    # O proxy LiteLLM/Azure OpenAI exige isso para modelos GPT-5 / o1 / o3
+    if model_type.lower() == "think" and (
+        config["model"].startswith("azure/") 
+        or config["model"].startswith("openai/")
+        or "gpt" in config["model"].lower()
+        or "o1" in config["model"].lower()
+        or "o3" in config["model"].lower()
+    ):
         temperature = 1.0
         logger.debug(
-            "Modelo 'think' detectado - forçando temperature=1.0 (exigido pelo Azure)"
+            f"Modelo 'think' Azure/OpenAI detectado ({config['model']}) - forçando temperature=1.0"
         )
 
     # Prepara parâmetros do ChatOpenAI

--- a/default.env
+++ b/default.env
@@ -76,6 +76,8 @@ ASSISTENTE_SUMMARIZE_CHUNK_SIZE=16000    # Tamanho de entrada de cada segmento a
 ASSISTENTE_SUMMARIZE_CHUNK_MAX_OUTPUT=4000 # Tamanho maximo da saida de cada resumo.
 LITELLM_PORT=4000                       # Porta interna/externa do proxy LiteLLM.
 ASSISTENTE_LITELLM_PROXY_URL="http://infra-litellm:${LITELLM_PORT}" # URL interna do proxy LiteLLM (hostname = nome do servico em docker-compose.yml).
+LITELLM_VERTEX_PROJECT=""                  # ID do projeto GCP para integracao com Vertex AI.
+LITELLM_VERTEX_LOCATION="us-central1"       # Regiao do GCP para os servicos do Vertex AI.
 ASSISTENTE_PORT=8088                    # Porta externa padrao publicada para o Assistente.
 
 # Configuracoes para deploy externo.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -463,6 +463,9 @@ services:
     networks:
       - seiia
     command: --config /app/config.yaml --port ${LITELLM_PORT:-4000} --host 0.0.0.0
+    env_file:
+      - default.env
+      - security.env
     volumes:
       - ./litellm_config.yaml:/app/config.yaml:ro
 

--- a/docs/VERTEX_AI.md
+++ b/docs/VERTEX_AI.md
@@ -1,0 +1,92 @@
+# Guia de Configuração: Integração com Google Cloud Vertex AI
+
+Este guia orienta o administrador do sistema sobre como configurar o **SEI-IA** para utilizar a plataforma **Vertex AI** (Gemini Enterprise Agent Platform) do Google Cloud, habilitando modelos como Gemini, Gemma, Anthropic Claude, entre outros.
+
+A integração é realizada de forma transparente utilizando o **LiteLLM Proxy** contido na stack do SEI-IA.
+
+---
+
+## Passo 1: Configuração no Google Cloud Platform (GCP)
+
+Para permitir a autenticação do LiteLLM no Google Cloud, siga as etapas abaixo:
+
+1. **Acessar o Console**: Vá para o [Google Cloud Console](https://console.cloud.google.com/).
+2. **Selecionar o Projeto**: Escolha o projeto do GCP que deseja utilizar para faturamento e consumo das APIs de IA.
+3. **Ativar a API do Vertex AI**:
+   * Vá em **APIs & Services** > **Library**.
+   * Busque por **Vertex AI API** e clique em **Enable**.
+4. **Criar uma Conta de Serviço (Service Account)**:
+   * Vá em **IAM & Admin** > **Service Accounts**.
+   * Clique em **Create Service Account**.
+   * Nomeie a conta (ex: `sei-ia-proxy`) e clique em **Create and Continue**.
+5. **Conceder Permissões (Roles)**:
+   * Na etapa de permissões, adicione a role **Vertex AI User** (`roles/aiplatform.user`).
+   * Clique em **Done** para concluir a criação.
+6. **Gerar a Chave de Acesso JSON**:
+   * Na lista de contas de serviço, clique na conta criada.
+   * Vá na aba **Keys** > **Add Key** > **Create New Key**.
+   * Escolha o formato **JSON** e clique em **Create**.
+   * O download do arquivo `.json` contendo as credenciais privadas será iniciado. Guarde esse arquivo em local seguro.
+
+---
+
+## Passo 2: Configuração no Servidor SEI-IA
+
+No servidor onde a stack do SEI-IA está instalada, configure as variáveis de ambiente nos arquivos `.env` para carregar as credenciais do GCP.
+
+### 1. No arquivo `default.env`
+Certifique-se de que a região e o ID do projeto no GCP estão preenchidos:
+```ini
+LITELLM_VERTEX_PROJECT="seu-project-id-no-gcp"
+LITELLM_VERTEX_LOCATION="us-central1" # Região de preferência para o Vertex AI
+```
+
+### 2. No arquivo `security.env`
+Adicione o conteúdo do arquivo JSON da chave privada como uma string de linha única, além de mapear os modelos desejados:
+
+```ini
+# Configuração dos modelos apontando para o provedor Vertex AI
+LITELLM_STANDARD_MODEL="vertex_ai/gemini-2.5-pro"
+LITELLM_MINI_MODEL="vertex_ai/gemini-3.5-flash"
+LITELLM_NANO_MODEL="vertex_ai/gemini-3.1-flash-lite"
+LITELLM_EMBEDDING_MODEL="vertex_ai/gemini-embedding-2"
+
+# JSON da conta de serviço obtido no Passo 1 (copie o conteúdo completo do arquivo .json e coloque em uma linha)
+LITELLM_VERTEX_CREDENTIALS='{"type": "service_account", "project_id": "seu-project-id", ...}'
+```
+
+> [!TIP]
+> Caso queira utilizar outros modelos suportados pelo Vertex AI Model Garden, basta definir o prefixo `vertex_ai/` seguido do nome do modelo no GCP. Exemplos:
+> * `LITELLM_STANDARD_MODEL="vertex_ai/claude-sonnet-4-6"`
+> * `LITELLM_STANDARD_MODEL="vertex_ai/gemma-4-26b-a4b-it-maas"`
+
+---
+
+## Passo 3: Aplicar as Configurações
+
+Para regenerar a configuração do LiteLLM Proxy e reiniciar a stack de containers:
+
+1. **Rodar o Script de Configuração**:
+   Se você utiliza o GitLab CI ou rodar localmente no host:
+   ```bash
+   bash .gitlab/scripts/generate_config_files.sh
+   ```
+   *(Este comando lerá o template e as novas variáveis de ambiente para gerar o arquivo `litellm_config.yaml` mapeando corretamente as credenciais do Vertex AI).*
+
+2. **Reiniciar os Serviços**:
+   ```bash
+   make down
+   make up
+   ```
+
+3. **Verificar os Logs**:
+   Certifique-se de que o container do LiteLLM iniciou sem erros de autenticação:
+   ```bash
+   docker compose logs infra-litellm
+   ```
+
+4. **Executar a Verificação Integrada**:
+   Rode os testes internos para certificar-se de que a comunicação está funcionando:
+   ```bash
+   make check
+   ```

--- a/litellm_config.template.yaml
+++ b/litellm_config.template.yaml
@@ -5,6 +5,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: 32768
     model_info:
       base_model: ${LITELLM_STANDARD_MODEL}
@@ -15,6 +18,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: 32768
     model_info:
       base_model: ${LITELLM_MINI_MODEL}
@@ -25,6 +31,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: 32000
     model_info:
       base_model: ${LITELLM_NANO_MODEL}
@@ -35,6 +44,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: ${LITELLM_THINK_MAX_TOKENS}
       reasoning_effort: "medium"
     model_info:
@@ -46,6 +58,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: ${LITELLM_THINK_MAX_TOKENS}
       reasoning_effort: "low"
     model_info:
@@ -57,6 +72,9 @@ model_list:
       api_base: ${LITELLM_STANDARD_API_BASE}
       api_key: ${LITELLM_STANDARD_API_KEY}
       api_version: "${LITELLM_STANDARD_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
       max_completion_tokens: ${LITELLM_THINK_MAX_TOKENS}
       reasoning_effort: "none"
     model_info:
@@ -68,6 +86,9 @@ model_list:
       api_base: ${LITELLM_EMBEDDING_API_BASE}
       api_key: ${LITELLM_EMBEDDING_API_KEY}
       api_version: "${LITELLM_EMBEDDING_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
     model_info:
       base_model: ${LITELLM_EMBEDDING_MODEL}
 
@@ -77,8 +98,12 @@ model_list:
       api_base: ${LITELLM_STT_API_BASE}
       api_key: ${LITELLM_STT_API_KEY}
       api_version: "${LITELLM_STT_API_VERSION}"
+      vertex_project: "${LITELLM_VERTEX_PROJECT}"
+      vertex_location: "${LITELLM_VERTEX_LOCATION}"
+      vertex_credentials: "${LITELLM_VERTEX_CREDENTIALS}"
     model_info:
       base_model: ${LITELLM_STT_MODEL}
+
 
 # ============================================================================
 # Configuracoes de Retry e Reliability

--- a/security_example.env
+++ b/security_example.env
@@ -50,13 +50,24 @@ ASSISTENTE_LITELLM_EMBEDDING_MODEL_NAME=
 ASSISTENTE_LITELLM_STT_MODEL_NAME=
 ASSISTENTE_OCR_MODEL=
 # Modelos no litellm_config (deve incluir prefixo do provedor).
-# Conexao direta com Azure:  azure/gpt-5.4
-# Via LiteLLM proxy central: openai/seiia-ds
+# Exemplos com Azure/OpenAI:  azure/gpt-4o, azure/gpt-4o-mini
+# Exemplos com Vertex AI (Gemini, Gemma, Claude, GPT-OSS): 
+#   vertex_ai/gemini-2.5-pro, vertex_ai/gemini-3.5-flash, vertex_ai/gemini-3.1-flash-lite,
+#   vertex_ai/gemma-4-26b-a4b-it-maas, vertex_ai/claude-opus-4-8, vertex_ai/claude-sonnet-4-6,
+#   vertex_ai/claude-haiku-4-5, vertex_ai/gpt-oss-120b-maas, vertex_ai/gpt-oss-20b-maas
+# Exemplo de embeddings com Vertex AI: vertex_ai/gemini-embedding-2
 LITELLM_STANDARD_MODEL=
 LITELLM_MINI_MODEL=
 LITELLM_NANO_MODEL=
 # Limite de tokens de saida para modelos think (varia por ambiente, ex: 32768 em dev, 102400 em prod).
 LITELLM_THINK_MAX_TOKENS=
+
+# ID do projeto GCP para integracao com Vertex AI (opcional se definido em default.env).
+LITELLM_VERTEX_PROJECT=
+# Regiao do GCP para os servicos do Vertex AI (opcional se definido em default.env).
+LITELLM_VERTEX_LOCATION=
+# Credenciais do Google Cloud para Vertex AI (JSON da Service Account em formato string).
+LITELLM_VERTEX_CREDENTIALS=
 
 #### Integracao com a API do SEI
 # Identificador do servico na API do SEI.


### PR DESCRIPTION
## Descrição
Este Pull Request adiciona suporte nativo para integração do SEI-IA com a plataforma **Vertex AI (Gemini Enterprise Agent Platform)** do Google Cloud, permitindo o uso de modelos da família Gemini, Gemma, Anthropic Claude, entre outros.

Como a aplicação do assistente já consome o LiteLLM Proxy de forma desacoplada, nenhuma alteração de lógica de negócio foi necessária. Toda a implementação foi feita a nível de infraestrutura, deployment e flexibilização de parâmetros.

## Alterações Realizadas

### 🛠️ Infraestrutura e Configurações
* **`litellm_config.template.yaml`**: Adicionados os parâmetros do GCP/Vertex AI (`vertex_project`, `vertex_location` e `vertex_credentials`) no bloco de parâmetros de todos os modelos da stack.
* **`docker-compose.yml`**: Adicionado o mapeamento do `env_file` para o container do `infra-litellm` para expor as credenciais do Google Cloud em tempo de execução.
* **`default.env` e `security_example.env`**: Incluídas as definições padrão e comentários de exemplo para os modelos mais novos (como Gemini 3.5, Claude 4, Gemma 4, GPT-OSS e embeddings).
* **`.gitlab/scripts/generate_config_files.sh`**: Atualizado para realizar a substituição das novas variáveis de ambiente e ajustada a validação para que a geração da configuração do LiteLLM não seja pulada caso a chave legada da OpenAI esteja ausente, mas as credenciais do Vertex AI estejam presentes.

### 🧠 Ajustes de Compatibilidade de Modelos
* **`aplicacoes/assistente/sei_ia/services/llm_models/get_model.py`**: A lógica que força `temperature=1.0` para modelos do tipo `think` foi restrita aos modelos do Azure/OpenAI (onde é mandatória). Isso evita quebras e comportamento excessivamente criativo em modelos de raciocínio de outros provedores (como Claude ou Gemini) que não exigem essa restrição.

### 📖 Documentação
* **`docs/VERTEX_AI.md`**: Criado um guia passo a passo ensinando o administrador a criar a Conta de Serviço no GCP, conceder a permissão necessária (`roles/aiplatform.user`), gerar as chaves e configurar o SEI-IA.

## Testes Realizados
* O script de geração de configurações foi testado localmente simulando as credenciais do GCP. O arquivo `litellm_config.yaml` foi gerado perfeitamente com os prefixos `vertex_ai/` e parâmetros de autenticação corretos, mantendo a retrocompatibilidade com Azure.